### PR TITLE
Use http-cookie instead of cookiejar for better standards compliance, compatibility and security.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Faraday middleware to manage client-side cookies
 
 ## Description
 
-This gem is a piece of Faraday middleware that adds client-side Cookies management, using [cookiejar gem](https://github.com/dwaite/cookiejar).
+This gem is a piece of Faraday middleware that adds client-side Cookies management, using [http-cookie gem](https://github.com/sparklemotion/http-cookie).
 
 ## Installation
 

--- a/faraday-cookie_jar.gemspec
+++ b/faraday-cookie_jar.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday", ">= 0.7.4"
-  spec.add_dependency "cookiejar"
+  spec.add_dependency "http-cookie", "~> 1.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Hi,

I recently released a new gem called http-cookie that handles HTTP cookies in the way described in RFC 6265 and the behavior adopted by real world browsers.  It offers better standards compliance, compatibility and security among others.

Applying this patch only does a replacement, but it would be nice if user can pass options to the constructor and have access to the jar.
