### PR TITLE
fix specs (rspec compatibility issue?)

### DIFF
--- a/spec/faraday-cookie_jar/cookie_jar_spec.rb
+++ b/spec/faraday-cookie_jar/cookie_jar_spec.rb
@@ -35,7 +35,7 @@ describe Faraday::CookieJar do
 
     conn_with_jar.get('/default')
 
-    expect(cookie_jar.empty?).to be_false
+    expect(cookie_jar.empty?).to be false
 
   end
 


### PR DESCRIPTION
`rake spec` does not work on the latest rspec :(