### PR TITLE
Do not update the cookie with identical information

### DIFF
--- a/lib/faraday/cookie_jar.rb
+++ b/lib/faraday/cookie_jar.rb
@@ -13,7 +13,9 @@ module Faraday
       unless cookies.empty?
         cookie_value = HTTP::Cookie.cookie_value(cookies)
         if env[:request_headers]["Cookie"]
-          env[:request_headers]["Cookie"] = cookie_value + ';' + env[:request_headers]["Cookie"]
+          unless env[:request_headers]["Cookie"] == cookie_value
+            env[:request_headers]["Cookie"] = cookie_value + ';' + env[:request_headers]["Cookie"]
+          end
         else
           env[:request_headers]["Cookie"] = cookie_value
         end


### PR DESCRIPTION
When using Faraday with FollowRedirects, if the first request has a cookie in its request headers, each redirect would append a copy of the cookie without this change.