### PR TITLE
Avoid checking (and preloading) Faraday only to support 0.7.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.7  Tue Sep  1 22:01:00 EDT 2020
+
+- Avoid loading Faraday by assuming Faraday registry API (chesterbr)
+- To support change above, require Faraday 0.8 as a minimum (chesterbr)
+
 ## 0.0.6  Tue Jan 21 16:34:35 PST 2014
 
 - Support Faraday 0.9 registry API (cameron-martin)

--- a/faraday-cookie_jar.gemspec
+++ b/faraday-cookie_jar.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", ">= 0.7.4"
+  spec.add_dependency "faraday", ">= 0.8.0"
   spec.add_dependency "http-cookie", "~> 1.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/lib/faraday/cookie_jar.rb
+++ b/lib/faraday/cookie_jar.rb
@@ -32,8 +32,6 @@ module Faraday
   end
 end
 
-if Faraday.respond_to? :register_middleware
-  Faraday.register_middleware :cookie_jar => lambda { Faraday::CookieJar }
-elsif Faraday::Middleware.respond_to? :register_middleware
+if Faraday::Middleware.respond_to? :register_middleware
   Faraday::Middleware.register_middleware :cookie_jar => Faraday::CookieJar
 end

--- a/lib/faraday/cookie_jar/version.rb
+++ b/lib/faraday/cookie_jar/version.rb
@@ -1,5 +1,5 @@
 module Faraday
   module CookieJarVersion
-    VERSION = "0.0.6"
+    VERSION = "0.0.7"
   end
 end


### PR DESCRIPTION
### Context

An earlier update on this project added support to Faraday middleware API (which is the only supported way as of now). Unfortunately, the fallback check (`Faraday.responds_to?` in the [registration code](https://github.com/miyagawa/faraday-cookie_jar/blob/master/lib/faraday/cookie_jar.rb#L35-L39) - that is, the `if` in:

```ruby
if Faraday.respond_to? :register_middleware
  Faraday.register_middleware :cookie_jar => lambda { Faraday::CookieJar }
elsif Faraday::Middleware.respond_to? :register_middleware
  Faraday::Middleware.register_middleware :cookie_jar => Faraday::CookieJar
end
```

triggers a load of `Faraday` that messes up with its configurations configurations in some specific classloader/forking situations (happened in our CI system).

### Proposal

We considered flipping the checks, but verified that `Faraday::Middleware#register_middleware` works as far back as 0.8.0. So by slightly bumping the minimum version (still much below what most people should be using in recent years), we can just drop the initial test, fixing the issue for us (and potentially others) while DRYing the code a bit.

In fact, this seems to be what other middleware do these days. For example, [registration code](https://github.com/lostisland/faraday_middleware/blob/e45e8f75a00e260eb7a4719f252883d3015b18d3/lib/faraday_middleware.rb#L26) in [faraday_middleware](https://github.com/lostisland/faraday_middleware) goes like:

```ruby
  if Faraday::Middleware.respond_to? :register_middleware
    ...
    Faraday::Middleware.register_middleware \
      ...
  end
```

### Tests

Did not find an easy way to write a test, but given that a failure on registration will break the entire suite, it can be used as a test on itself, so I ran the specs on different Faraday versions.

They ran successfully with Faraday 1.0.1 (the current one), so I went back and verified that even Faraday 0.8.0 works, so I reduced the impact by only bumped the minimum to it (instead of 0.9.0, which was the version that motivated @cameron-martin to add the support in first place).

### Version and Changelog

I could not find instructions on whether you'd like to just receive the change and do the changelog/version bump yourself, so I made those in a separate commit (which I can revert/squash if you prefer, just let me know).

Even though it is a theoretical compatibility change, projects with Faraday versions that don't support the API will not update via Bundler, so I found it safe to just bump the patch component.