### PR TITLE
Add the ability to configure loading and saving cookie jar to a file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ rdoc
 spec/reports
 test/tmp
 test/version_tmp
-tmp
+spec/tmp

--- a/lib/faraday/cookie_jar.rb
+++ b/lib/faraday/cookie_jar.rb
@@ -3,12 +3,30 @@ require "http/cookie_jar"
 
 module Faraday
   class CookieJar < Faraday::Middleware
+    def self.filename
+      @filename
+    end
+    def self.filename=(filename)
+      @filename = filename
+    end
+    def self.save_options
+      @save_options
+    end
+    def self.save_options=(save_options)
+      @save_options = save_options
+    end
+
+    def self.configure(&block)
+      yield self
+    end
+
     def initialize(app, options = {})
       super(app)
       @jar = options[:jar] || HTTP::CookieJar.new
     end
 
     def call(env)
+      @jar.load(Faraday::CookieJar.filename) if !Faraday::CookieJar.filename.nil? && File.exist?(Faraday::CookieJar.filename)
       cookies = @jar.cookies(env[:url])
       unless cookies.empty?
         cookie_value = HTTP::Cookie.cookie_value(cookies)
@@ -26,6 +44,7 @@ module Faraday
           if set_cookie = res[:response_headers]["Set-Cookie"]
             @jar.parse(set_cookie, env[:url])
           end
+          @jar.save(Faraday::CookieJar.filename, Faraday::CookieJar.save_options) unless Faraday::CookieJar.filename.nil?
         end
       end
     end

--- a/spec/data/default-cookie.yml
+++ b/spec/data/default-cookie.yml
@@ -1,0 +1,13 @@
+---
+- !ruby/object:HTTP::Cookie
+  name: foo
+  value: bar
+  domain: faraday.example.com
+  for_domain: false
+  path: "/"
+  secure: false
+  httponly: false
+  expires:
+  max_age:
+  created_at: 2021-07-21 08:20:53.459479000 +10:00
+  accessed_at: 2021-07-21 08:48:57.821596000 +10:00

--- a/spec/faraday-cookie_jar/cookie_jar_spec.rb
+++ b/spec/faraday-cookie_jar/cookie_jar_spec.rb
@@ -44,10 +44,52 @@ describe Faraday::CookieJar do
 
     response = conn.send('get') do |request|
       request.url '/multiple_cookies'
-      request.headers.merge!({:Cookie => 'language=english'})
+      request.headers.merge!({ :Cookie => 'language=english' })
     end
 
     expect(response.body).to eq('foo=bar;language=english')
+  end
+
+  context 'when configured to load and save cookies from a file.' do
+    after :each do
+      Faraday::CookieJar.filename = nil
+      Faraday::CookieJar.save_options = nil
+    end
+
+    let(:saved_cookies) {
+      jar = HTTP::CookieJar.new.load(Faraday::CookieJar.filename)
+      jar.cookies('http://faraday.example.com')
+    }
+
+    it 'loads cookies from a file' do
+      Faraday::CookieJar.filename = './spec/data/default-cookie.yml'
+      Faraday::CookieJar.save_options = { session: true }
+      expect(conn.get('/dump').body).to eq('foo=bar')
+    end
+
+    it 'saves cookies in a file' do
+      Faraday::CookieJar.filename = './spec/tmp/default-cookie.yml'
+      Faraday::CookieJar.save_options = { session: true }
+      File.delete Faraday::CookieJar.filename if File.exist? Faraday::CookieJar.filename
+      conn.get('/default')
+      expect(File).to exist(Faraday::CookieJar.filename)
+      expect(saved_cookies).to match_array([have_attributes(
+                                              name: 'foo',
+                                              value: 'bar'
+                                            )])
+    end
+
+    it 'expires cookie' do
+      Faraday::CookieJar.filename = './spec/tmp/expired-cookie.yml'
+      Faraday::CookieJar.save_options = { session: true }
+      File.delete Faraday::CookieJar.filename if File.exist? Faraday::CookieJar.filename
+      conn.get('/expires')
+      expect(conn.get('/dump').body).to eq('foo=bar')
+      sleep 2
+      expect(conn.get('/dump').body).to_not eq('foo=bar')
+      expect(saved_cookies).to match_array([])
+    end
+
   end
 end
 


### PR DESCRIPTION
I wanted the ability to configure the use of faraday-cookie_jar by another gem to be able to load and save cookie data to a file. 
I.e.
``` ./config/initializers/faraday-cookie_jar.rb
Faraday::CookieJar.configure do |config|
  config.filename = "#{Rails.root}/tmp/cookies.yml"
  config.save_options = { session: true }
end
```