### PR TITLE
wrap interactions with CookieJar in a mutex

### DIFF
--- a/faraday-cookie_jar.gemspec
+++ b/faraday-cookie_jar.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday", ">= 0.8.0"
   spec.add_dependency "http-cookie", "~> 1.0.0"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "sinatra"


### PR DESCRIPTION
This is a possible solution for #16; it simply wraps the interactions with CookieJar (but, importantly, not the `@app.call`) in a mutex to ensure thread-safety.