### PR TITLE
Accept any http-cookie 1.x version

### DIFF
--- a/faraday-cookie_jar.gemspec
+++ b/faraday-cookie_jar.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday", ">= 0.8.0"
-  spec.add_dependency "http-cookie", "~> 1.0.0"
+  spec.add_dependency "http-cookie", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
1.1.0 was recently released and doesn't contain any changes that would break cookie_jar.
Let's assume the next versions of 1.x will remain compatible too.